### PR TITLE
Update everything to 1.21.1 and a couple of new features

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "maven" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4.7.1
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: temurin
           cache: maven
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,12 +25,12 @@ jobs:
         run: mvn -B package --file pom.xml
 
       - name: Copy artifacts
-        run: cp target/CreativeHeads.jar .
+        run: |
+          JAR_FILE=$(find target -name "*.jar" -type f | head -n 1)
+          cp "$JAR_FILE" ./RestartAR.jar
 
       - name: Upload bundle
         uses: actions/upload-artifact@v4.6.2
         with:
-          name: Bundle
-          path: |
-            CreativeHeads.jar
-            LICENSE.txt
+          name: RestartAR-build
+          path: RestartAR.jar

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,6 +21,11 @@ jobs:
           distribution: temurin
           cache: maven
 
+      - name: BuildTools
+        run: |
+          curl -fLsS "https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar" -o BuildTools.jar &&
+          java -jar BuildTools.jar --rev 1.21.1 --remapped
+
       - name: Build with Maven
         run: mvn -B package --file pom.xml
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,7 +28,7 @@ jobs:
         run: cp target/CreativeHeads.jar .
 
       - name: Upload bundle
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: Bundle
           path: |

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,14 +17,14 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4.7.1
         with:
-          java-version: '21'
+          java-version: '17'
           distribution: temurin
           cache: maven
 
       - name: BuildTools
         run: |
           curl -fLsS "https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar" -o BuildTools.jar &&
-          java -jar BuildTools.jar --rev 1.21.1 --remapped
+          java -jar BuildTools.jar --rev 1.20.5 --remapped
 
       - name: Build with Maven
         run: mvn -B package --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,12 +21,6 @@ jobs:
           distribution: temurin
           cache: maven
 
-      - name: BuildTools
-        if: false
-        run: |
-          curl -fLsS "https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar" -o BuildTools.jar &&
-          java -jar BuildTools.jar --rev 1.19 --remapped
-
       - name: Build with Maven
         run: mvn -B package --file pom.xml
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4.7.1
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: temurin
           cache: maven
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,7 +24,7 @@ jobs:
       - name: BuildTools
         run: |
           curl -fLsS "https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar" -o BuildTools.jar &&
-          java -jar BuildTools.jar --rev 1.20.5 --remapped
+          java -jar BuildTools.jar --rev 1.19 --remapped
 
       - name: Build with Maven
         run: mvn -B package --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.2.2
 
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4.7.1
         with:
           java-version: '11'
           distribution: temurin

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -22,6 +22,7 @@ jobs:
           cache: maven
 
       - name: BuildTools
+        if: false
         run: |
           curl -fLsS "https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar" -o BuildTools.jar &&
           java -jar BuildTools.jar --rev 1.19 --remapped

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,12 +25,12 @@ jobs:
         run: mvn -B package --file pom.xml
 
       - name: Copy artifacts
-        run: |
-          JAR_FILE=$(find target -name "*.jar" -type f | head -n 1)
-          cp "$JAR_FILE" ./RestartAR.jar
+        run: cp target/CreativeHeads.jar .
 
       - name: Upload bundle
         uses: actions/upload-artifact@v4.6.2
         with:
-          name: RestartAR-build
-          path: RestartAR.jar
+          name: Bundle
+          path: |
+            CreativeHeads.jar
+            LICENSE.txt

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
-            <version>3.41.2.2</version>
+            <version>3.49.1.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.16.5-R0.1-SNAPSHOT</version>
+            <version>1.21.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.4</version>
+                <version>3.6.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>commons-dbutils</groupId>
             <artifactId>commons-dbutils</artifactId>
-            <version>1.7</version>
+            <version>1.8.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.14.0</version>
                 <configuration>
                     <compilerArgs>
                         <arg>-Xlint:deprecation</arg>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.6.0</version>
+                <version>3.6.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
-            <version>3.49.1.0</version>
+            <version>3.50.3.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -109,15 +109,15 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <compilerArgs>
-                        <arg>-Xlint:deprecation</arg>
-                    </compilerArgs>
-                </configuration>
-            </plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <compilerArgs>
+                        <arg>-Xlint:deprecation</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>com.mojang</groupId>
             <artifactId>brigadier</artifactId>
-            <version>1.0.18</version>
+            <version>1.0.500</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.38</version>
+            <version>1.18.42</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.22</version>
+            <version>1.18.38</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -27,8 +27,8 @@
         </dependency>
         <dependency>
             <groupId>org.spigotmc</groupId>
-            <artifactId>spigot-api</artifactId>
-            <version>1.21.1-R0.1-SNAPSHOT</version>
+            <artifactId>spigot</artifactId>
+            <version>1.19</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.19</version>
+            <version>1.19-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,8 @@
     <name>CreativeHeads</name>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-csv</artifactId>
-            <version>1.9.0</version>
+            <version>1.14.0</version>
         </dependency>
         <dependency>
             <groupId>org.spigotmc</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
-            <version>3.34.0</version>
+            <version>3.41.2.2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,8 @@
     <name>CreativeHeads</name>
 
     <properties>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.14.0</version>
+                <version>3.14.1</version>
                 <configuration>
                     <compilerArgs>
                         <arg>-Xlint:deprecation</arg>

--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,8 @@
     <name>CreativeHeads</name>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-csv</artifactId>
-            <version>1.14.0</version>
+            <version>1.14.1</version>
         </dependency>
         <dependency>
             <groupId>org.spigotmc</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>com.mojang</groupId>
             <artifactId>brigadier</artifactId>
-            <version>1.0.500</version>
+            <version>1.0.18</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.19-SNAPSHOT</version>
+            <version>1.21.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,16 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <compilerArgs>
+                        <arg>-Xlint:deprecation</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         </dependency>
         <dependency>
             <groupId>org.spigotmc</groupId>
-            <artifactId>spigot</artifactId>
+            <artifactId>spigot-api</artifactId>
             <version>1.19</version>
             <scope>provided</scope>
         </dependency>

--- a/src/main/java/io/github/theluca98/creativeheads/command/PlayerHeadCommand.java
+++ b/src/main/java/io/github/theluca98/creativeheads/command/PlayerHeadCommand.java
@@ -71,7 +71,7 @@ public class PlayerHeadCommand extends Subcommand {
                 sender.playSound(sender.getLocation(), Sound.BLOCK_NOTE_BLOCK_DIDGERIDOO, SoundCategory.MASTER, 1, 0);
             }
         }, plugin.getExecutor()).exceptionally(e -> {
-            if (e instanceof PlayerNotFound) {
+            if (e.getCause() instanceof PlayerNotFound) {
                 sender.sendMessage(ChatColor.RED + e.getMessage());
             } else {
                 sender.sendMessage(ChatColor.RED + "An internal error occurred, please try again later.");

--- a/src/main/java/io/github/theluca98/creativeheads/command/PlayerHeadCommand.java
+++ b/src/main/java/io/github/theluca98/creativeheads/command/PlayerHeadCommand.java
@@ -23,6 +23,7 @@ import com.mojang.brigadier.context.CommandContext;
 import io.github.theluca98.creativeheads.CreativeHeads;
 import io.github.theluca98.creativeheads.core.command.Subcommand;
 import io.github.theluca98.creativeheads.util.ItemBuilder;
+import io.github.theluca98.creativeheads.util.exception.PlayerNotFound;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.Sound;
@@ -70,8 +71,12 @@ public class PlayerHeadCommand extends Subcommand {
                 sender.playSound(sender.getLocation(), Sound.BLOCK_NOTE_BLOCK_DIDGERIDOO, SoundCategory.MASTER, 1, 0);
             }
         }, plugin.getExecutor()).exceptionally(e -> {
-            sender.sendMessage(ChatColor.RED + "An internal error occurred, please try again later.");
-            plugin.logException(e);
+            if (e instanceof PlayerNotFound) {
+                sender.sendMessage(ChatColor.RED + e.message);
+            } else {
+                sender.sendMessage(ChatColor.RED + "An internal error occurred, please try again later.");
+                plugin.logException(e);
+            }
             return null;
         });
     }

--- a/src/main/java/io/github/theluca98/creativeheads/command/PlayerHeadCommand.java
+++ b/src/main/java/io/github/theluca98/creativeheads/command/PlayerHeadCommand.java
@@ -72,7 +72,8 @@ public class PlayerHeadCommand extends Subcommand {
             }
         }, plugin.getExecutor()).exceptionally(e -> {
             if (e.getCause() instanceof PlayerNotFound) {
-                sender.sendMessage(ChatColor.RED + e.getMessage());
+                sender.sendMessage(ChatColor.RED + e.getCause().getMessage());
+                plugin.logException(e.getMessage());
             } else {
                 sender.sendMessage(ChatColor.RED + "An internal error occurred, please try again later.");
                 plugin.logException(e);

--- a/src/main/java/io/github/theluca98/creativeheads/command/PlayerHeadCommand.java
+++ b/src/main/java/io/github/theluca98/creativeheads/command/PlayerHeadCommand.java
@@ -73,7 +73,7 @@ public class PlayerHeadCommand extends Subcommand {
         }, plugin.getExecutor()).exceptionally(e -> {
             if (e.getCause() instanceof PlayerNotFound) {
                 sender.sendMessage(ChatColor.RED + e.getCause().getMessage());
-                plugin.logException(e.getMessage());
+                plugin.logException(e.getCause());
             } else {
                 sender.sendMessage(ChatColor.RED + "An internal error occurred, please try again later.");
                 plugin.logException(e);

--- a/src/main/java/io/github/theluca98/creativeheads/command/PlayerHeadCommand.java
+++ b/src/main/java/io/github/theluca98/creativeheads/command/PlayerHeadCommand.java
@@ -72,7 +72,7 @@ public class PlayerHeadCommand extends Subcommand {
             }
         }, plugin.getExecutor()).exceptionally(e -> {
             if (e instanceof PlayerNotFound) {
-                sender.sendMessage(ChatColor.RED + e.message);
+                sender.sendMessage(ChatColor.RED + e.getMessage());
             } else {
                 sender.sendMessage(ChatColor.RED + "An internal error occurred, please try again later.");
                 plugin.logException(e);

--- a/src/main/java/io/github/theluca98/creativeheads/command/SearchCommand.java
+++ b/src/main/java/io/github/theluca98/creativeheads/command/SearchCommand.java
@@ -53,7 +53,7 @@ public class SearchCommand extends Subcommand {
             .thenApplyAsync(list -> new Pagination<>(list, HeadListView.PAGE_SIZE))
             .thenAcceptAsync((results) -> {
                 if (results.hasPage(0)) {
-                    new HeadListView(plugin, results, 0).open(sender);
+                    new HeadListView(plugin, results, 0, query).open(sender);
                 } else {
                     sender.sendMessage(ChatColor.RED + "The search returned no results.");
                 }

--- a/src/main/java/io/github/theluca98/creativeheads/core/command/MainCommandDispatcher.java
+++ b/src/main/java/io/github/theluca98/creativeheads/core/command/MainCommandDispatcher.java
@@ -24,6 +24,7 @@ import com.mojang.brigadier.ParseResults;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.suggestion.Suggestion;
 import com.mojang.brigadier.tree.CommandNode;
+import com.mojang.brigadier.context.CommandContext;
 import io.github.theluca98.creativeheads.CreativeHeads;
 import lombok.SneakyThrows;
 import org.bukkit.ChatColor;

--- a/src/main/java/io/github/theluca98/creativeheads/core/command/MainCommandDispatcher.java
+++ b/src/main/java/io/github/theluca98/creativeheads/core/command/MainCommandDispatcher.java
@@ -91,7 +91,7 @@ public class MainCommandDispatcher implements CommandExecutor, TabCompleter {
         if (results.getContext().getNodes().isEmpty()) {
             currentNode = dispatcher.getRoot();
         } else {
-            currentNode = results.getContext().getNodes().get(results.getContext().getNodes().size() - 1);
+            currentNode = results.getContext().getNodes().get(results.getContext().getNodes().size() - 1).getNode();
         }
         var currentPath = String.join(" ", dispatcher.getPath(currentNode));
         return dispatcher.getSmartUsage(currentNode, results.getContext().getSource())

--- a/src/main/java/io/github/theluca98/creativeheads/core/command/MainCommandDispatcher.java
+++ b/src/main/java/io/github/theluca98/creativeheads/core/command/MainCommandDispatcher.java
@@ -23,6 +23,7 @@ import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.ParseResults;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.suggestion.Suggestion;
+import com.mojang.brigadier.context.ParsedCommandNode;
 import com.mojang.brigadier.tree.CommandNode;
 import io.github.theluca98.creativeheads.CreativeHeads;
 import lombok.SneakyThrows;

--- a/src/main/java/io/github/theluca98/creativeheads/core/command/MainCommandDispatcher.java
+++ b/src/main/java/io/github/theluca98/creativeheads/core/command/MainCommandDispatcher.java
@@ -88,11 +88,11 @@ public class MainCommandDispatcher implements CommandExecutor, TabCompleter {
 
     private List<String> getUsageStrings(ParseResults<CommandSender> results) {
         CommandNode<CommandSender> currentNode;
-        var nodes = results.getContext().getNodes();
+        List<ParsedCommandNode<CommandNode<CommandSender>>> nodes = results.getContext().getNodes();
         if (nodes.isEmpty()) {
             currentNode = dispatcher.getRoot();
         } else {
-            var last = nodes.get(nodes.size() - 1);
+            ParsedCommandNode<CommandNode<CommandSender>> last = nodes.get(nodes.size() - 1);
             currentNode = last.getNode();
         }
         var currentPath = String.join(" ", dispatcher.getPath(currentNode));

--- a/src/main/java/io/github/theluca98/creativeheads/core/command/MainCommandDispatcher.java
+++ b/src/main/java/io/github/theluca98/creativeheads/core/command/MainCommandDispatcher.java
@@ -91,7 +91,7 @@ public class MainCommandDispatcher implements CommandExecutor, TabCompleter {
         if (results.getContext().getNodes().isEmpty()) {
             currentNode = dispatcher.getRoot();
         } else {
-            currentNode = Iterables.getLast(results.getContext().getNodes()).getNode();
+            currentNode = results.getContext().getNodes().get(results.getContext().getNodes().size() - 1).getNode();
         }
         var currentPath = String.join(" ", dispatcher.getPath(currentNode));
         return dispatcher.getSmartUsage(currentNode, results.getContext().getSource())

--- a/src/main/java/io/github/theluca98/creativeheads/core/command/MainCommandDispatcher.java
+++ b/src/main/java/io/github/theluca98/creativeheads/core/command/MainCommandDispatcher.java
@@ -25,6 +25,7 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.suggestion.Suggestion;
 import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.context.ParsedCommandNode;
 import io.github.theluca98.creativeheads.CreativeHeads;
 import lombok.SneakyThrows;
 import org.bukkit.ChatColor;

--- a/src/main/java/io/github/theluca98/creativeheads/core/command/MainCommandDispatcher.java
+++ b/src/main/java/io/github/theluca98/creativeheads/core/command/MainCommandDispatcher.java
@@ -88,10 +88,11 @@ public class MainCommandDispatcher implements CommandExecutor, TabCompleter {
 
     private List<String> getUsageStrings(ParseResults<CommandSender> results) {
         CommandNode<CommandSender> currentNode;
-        if (results.getContext().getNodes().isEmpty()) {
+        List<ParsedCommandNode<CommandSender>> nodes = results.getContext().getNodes();
+        if (nodes.isEmpty()) {
             currentNode = dispatcher.getRoot();
         } else {
-            currentNode = results.getContext().getNodes().get(results.getContext().getNodes().size() - 1).getNode();
+            currentNode = nodes.get(nodes.size() - 1).getNode();
         }
         var currentPath = String.join(" ", dispatcher.getPath(currentNode));
         return dispatcher.getSmartUsage(currentNode, results.getContext().getSource())

--- a/src/main/java/io/github/theluca98/creativeheads/core/command/MainCommandDispatcher.java
+++ b/src/main/java/io/github/theluca98/creativeheads/core/command/MainCommandDispatcher.java
@@ -90,7 +90,7 @@ public class MainCommandDispatcher implements CommandExecutor, TabCompleter {
 
     private List<String> getUsageStrings(ParseResults<CommandSender> results) {
         CommandNode<CommandSender> currentNode;
-        List<ParsedCommandNode<CommandNode>> nodes = results.getContext().getNodes();
+        var nodes = results.getContext().getNodes();
         if (nodes.isEmpty()) {
             currentNode = dispatcher.getRoot();
         } else {

--- a/src/main/java/io/github/theluca98/creativeheads/core/command/MainCommandDispatcher.java
+++ b/src/main/java/io/github/theluca98/creativeheads/core/command/MainCommandDispatcher.java
@@ -23,7 +23,6 @@ import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.ParseResults;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.suggestion.Suggestion;
-import com.mojang.brigadier.context.ParsedCommandNode;
 import com.mojang.brigadier.tree.CommandNode;
 import io.github.theluca98.creativeheads.CreativeHeads;
 import lombok.SneakyThrows;
@@ -89,7 +88,7 @@ public class MainCommandDispatcher implements CommandExecutor, TabCompleter {
 
     private List<String> getUsageStrings(ParseResults<CommandSender> results) {
         CommandNode<CommandSender> currentNode;
-        List<ParsedCommandNode<CommandSender>> nodes = results.getContext().getNodes();
+        var nodes = results.getContext().getNodes();
         if (nodes.isEmpty()) {
             currentNode = dispatcher.getRoot();
         } else {

--- a/src/main/java/io/github/theluca98/creativeheads/core/command/MainCommandDispatcher.java
+++ b/src/main/java/io/github/theluca98/creativeheads/core/command/MainCommandDispatcher.java
@@ -24,6 +24,7 @@ import com.mojang.brigadier.ParseResults;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.suggestion.Suggestion;
 import com.mojang.brigadier.tree.CommandNode;
+import com.mojang.brigadier.context.ParsedCommandNode;
 import io.github.theluca98.creativeheads.CreativeHeads;
 import lombok.SneakyThrows;
 import org.bukkit.ChatColor;

--- a/src/main/java/io/github/theluca98/creativeheads/core/command/MainCommandDispatcher.java
+++ b/src/main/java/io/github/theluca98/creativeheads/core/command/MainCommandDispatcher.java
@@ -92,7 +92,8 @@ public class MainCommandDispatcher implements CommandExecutor, TabCompleter {
         if (nodes.isEmpty()) {
             currentNode = dispatcher.getRoot();
         } else {
-            currentNode = nodes.get(nodes.size() - 1).getNode();
+            var last = nodes.get(nodes.size() - 1);
+            currentNode = last.getNode();
         }
         var currentPath = String.join(" ", dispatcher.getPath(currentNode));
         return dispatcher.getSmartUsage(currentNode, results.getContext().getSource())

--- a/src/main/java/io/github/theluca98/creativeheads/core/command/MainCommandDispatcher.java
+++ b/src/main/java/io/github/theluca98/creativeheads/core/command/MainCommandDispatcher.java
@@ -91,7 +91,7 @@ public class MainCommandDispatcher implements CommandExecutor, TabCompleter {
         if (results.getContext().getNodes().isEmpty()) {
             currentNode = dispatcher.getRoot();
         } else {
-            currentNode = results.getContext().getNodes().get(results.getContext().getNodes().size() - 1).getNode();
+            currentNode = results.getContext().getNodes().get(results.getContext().getNodes().size() - 1);
         }
         var currentPath = String.join(" ", dispatcher.getPath(currentNode));
         return dispatcher.getSmartUsage(currentNode, results.getContext().getSource())

--- a/src/main/java/io/github/theluca98/creativeheads/core/command/MainCommandDispatcher.java
+++ b/src/main/java/io/github/theluca98/creativeheads/core/command/MainCommandDispatcher.java
@@ -24,7 +24,6 @@ import com.mojang.brigadier.ParseResults;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.suggestion.Suggestion;
 import com.mojang.brigadier.tree.CommandNode;
-import com.mojang.brigadier.context.ParsedCommandNode;
 import io.github.theluca98.creativeheads.CreativeHeads;
 import lombok.SneakyThrows;
 import org.bukkit.ChatColor;
@@ -89,12 +88,11 @@ public class MainCommandDispatcher implements CommandExecutor, TabCompleter {
 
     private List<String> getUsageStrings(ParseResults<CommandSender> results) {
         CommandNode<CommandSender> currentNode;
-        List<ParsedCommandNode<CommandNode<CommandSender>>> nodes = results.getContext().getNodes();
+        List<ParsedCommandNode<CommandNode>> nodes = results.getContext().getNodes();
         if (nodes.isEmpty()) {
             currentNode = dispatcher.getRoot();
         } else {
-            ParsedCommandNode<CommandNode<CommandSender>> last = nodes.get(nodes.size() - 1);
-            currentNode = last.getNode();
+            currentNode = nodes.get(nodes.size() - 1).getNode();
         }
         var currentPath = String.join(" ", dispatcher.getPath(currentNode));
         return dispatcher.getSmartUsage(currentNode, results.getContext().getSource())

--- a/src/main/java/io/github/theluca98/creativeheads/gui/HeadListView.java
+++ b/src/main/java/io/github/theluca98/creativeheads/gui/HeadListView.java
@@ -39,17 +39,17 @@ public class HeadListView extends InventoryGUI {
     }
     public HeadListView(CreativeHeads plugin, Pagination<CustomHead> results, int pageIndex) {
         super(plugin, String.format("Heads - Page %d of %d", pageIndex+1, results.pageCount()));
-        return openView(plugin, results, pageIndex);
+        return openView(plugin, results, pageIndex, "");
     }
     public HeadListView(CreativeHeads plugin, Pagination<CustomHead> results, String search) {
         this(plugin, results, 0, search);
     }
     public HeadListView(CreativeHeads plugin, Pagination<CustomHead> results, int pageIndex, String search) {
         super(plugin, String.format("Heads Search: "+search+" - Page %d of %d", pageIndex+1, results.pageCount()));
-        return openView(plugin, results, pageIndex);
+        return openView(plugin, results, pageIndex, search);
     }
 
-    public openView(CreativeHeads plugin, Pagination<CustomHead> results, int pageIndex) {
+    public openView(CreativeHeads plugin, Pagination<CustomHead> results, int pageIndex, String search) {
         checkState(results.hasPage(pageIndex), "Page does not exist");
         var page = results.getPage(pageIndex);
         for (var head : page) {
@@ -106,11 +106,23 @@ public class HeadListView extends InventoryGUI {
         }
 
         for (int i = 1; i <= 7; i++) {
-            addItem(
-                slot(5, i),
-                ItemBuilder.of(Material.GRAY_STAINED_GLASS_PANE).withName(ChatColor.RESET.toString()).build(),
-                ClickFunction.NONE
-            );
+            if (i == 4 && search == "") {
+                 addItem(
+                    slot(5, 4),
+                    ItemBuilder.of(Material.BARRIER).withName(ChatColor.YELLOW + "\u25B2 Back to categories \u25B2").build(),
+                    (player, click) -> {
+                        player.playSound(player.getLocation(), Sound.ITEM_BOOK_PAGE_TURN, 1, 1);
+                        new CategoryListView(plugin).open(player);
+                        return false;
+                    }
+                );
+            } else {
+                addItem(
+                    slot(5, i),
+                    ItemBuilder.of(Material.GRAY_STAINED_GLASS_PANE).withName(ChatColor.RESET.toString()).build(),
+                    ClickFunction.NONE
+                );
+            }
         }
     }
 

--- a/src/main/java/io/github/theluca98/creativeheads/gui/HeadListView.java
+++ b/src/main/java/io/github/theluca98/creativeheads/gui/HeadListView.java
@@ -49,7 +49,7 @@ public class HeadListView extends InventoryGUI {
         return openView(plugin, results, pageIndex, search);
     }
 
-    public openView(CreativeHeads plugin, Pagination<CustomHead> results, int pageIndex, String search) {
+    public bool openView(CreativeHeads plugin, Pagination<CustomHead> results, int pageIndex, String search) {
         checkState(results.hasPage(pageIndex), "Page does not exist");
         var page = results.getPage(pageIndex);
         for (var head : page) {

--- a/src/main/java/io/github/theluca98/creativeheads/gui/HeadListView.java
+++ b/src/main/java/io/github/theluca98/creativeheads/gui/HeadListView.java
@@ -39,17 +39,17 @@ public class HeadListView extends InventoryGUI {
     }
     public HeadListView(CreativeHeads plugin, Pagination<CustomHead> results, int pageIndex) {
         super(plugin, String.format("Heads - Page %d of %d", pageIndex+1, results.pageCount()));
-        return openView(plugin, results, pageIndex, "");
+        openView(plugin, results, pageIndex, "");
     }
     public HeadListView(CreativeHeads plugin, Pagination<CustomHead> results, String search) {
         this(plugin, results, 0, search);
     }
     public HeadListView(CreativeHeads plugin, Pagination<CustomHead> results, int pageIndex, String search) {
         super(plugin, String.format("Heads Search: "+search+" - Page %d of %d", pageIndex+1, results.pageCount()));
-        return openView(plugin, results, pageIndex, search);
+        openView(plugin, results, pageIndex, search);
     }
 
-    public boolean openView(CreativeHeads plugin, Pagination<CustomHead> results, int pageIndex, String search) {
+    public void openView(CreativeHeads plugin, Pagination<CustomHead> results, int pageIndex, String search) {
         checkState(results.hasPage(pageIndex), "Page does not exist");
         var page = results.getPage(pageIndex);
         for (var head : page) {

--- a/src/main/java/io/github/theluca98/creativeheads/gui/HeadListView.java
+++ b/src/main/java/io/github/theluca98/creativeheads/gui/HeadListView.java
@@ -49,7 +49,7 @@ public class HeadListView extends InventoryGUI {
         return openView(plugin, results, pageIndex, search);
     }
 
-    public bool openView(CreativeHeads plugin, Pagination<CustomHead> results, int pageIndex, String search) {
+    public boolean openView(CreativeHeads plugin, Pagination<CustomHead> results, int pageIndex, String search) {
         checkState(results.hasPage(pageIndex), "Page does not exist");
         var page = results.getPage(pageIndex);
         for (var head : page) {

--- a/src/main/java/io/github/theluca98/creativeheads/gui/HeadListView.java
+++ b/src/main/java/io/github/theluca98/creativeheads/gui/HeadListView.java
@@ -32,15 +32,24 @@ import org.bukkit.SoundCategory;
 import static com.google.common.base.Preconditions.checkState;
 
 public class HeadListView extends InventoryGUI {
-
     public static final int PAGE_SIZE = COLUMNS * 5;
 
     public HeadListView(CreativeHeads plugin, Pagination<CustomHead> results) {
         this(plugin, results, 0);
     }
-
     public HeadListView(CreativeHeads plugin, Pagination<CustomHead> results, int pageIndex) {
-        super(plugin, String.format("Heads - Page %d of %d", pageIndex + 1, results.pageCount()));
+        super(plugin, String.format("Heads - Page %d of %d", pageIndex+1, results.pageCount()));
+        return openView(plugin, results, pageIndex);
+    }
+    public HeadListView(CreativeHeads plugin, Pagination<CustomHead> results, String search) {
+        this(plugin, results, 0, search);
+    }
+    public HeadListView(CreativeHeads plugin, Pagination<CustomHead> results, int pageIndex, String search) {
+        super(plugin, String.format("Heads Search: "+search+" - Page %d of %d", pageIndex+1, results.pageCount()));
+        return openView(plugin, results, pageIndex);
+    }
+
+    public openView(CreativeHeads plugin, Pagination<CustomHead> results, int pageIndex) {
         checkState(results.hasPage(pageIndex), "Page does not exist");
         var page = results.getPage(pageIndex);
         for (var head : page) {

--- a/src/main/java/io/github/theluca98/creativeheads/gui/HeadListView.java
+++ b/src/main/java/io/github/theluca98/creativeheads/gui/HeadListView.java
@@ -45,8 +45,12 @@ public class HeadListView extends InventoryGUI {
         this(plugin, results, 0, search);
     }
     public HeadListView(CreativeHeads plugin, Pagination<CustomHead> results, int pageIndex, String search) {
-        super(plugin, String.format("Head search: "+search+" - Page %d/%d", pageIndex+1, results.pageCount()));
-        openView(plugin, results, pageIndex, search);
+        if (search == "") {
+            this(plugin, results, pageIndex);
+        } else {
+            super(plugin, String.format("Head search: "+search+" - Page %d/%d", pageIndex+1, results.pageCount()));
+            openView(plugin, results, pageIndex, search);
+        }
     }
 
     public void openView(CreativeHeads plugin, Pagination<CustomHead> results, int pageIndex, String search) {

--- a/src/main/java/io/github/theluca98/creativeheads/gui/HeadListView.java
+++ b/src/main/java/io/github/theluca98/creativeheads/gui/HeadListView.java
@@ -38,14 +38,14 @@ public class HeadListView extends InventoryGUI {
         this(plugin, results, 0);
     }
     public HeadListView(CreativeHeads plugin, Pagination<CustomHead> results, int pageIndex) {
-        super(plugin, String.format("Heads - Page %d of %d", pageIndex+1, results.pageCount()));
+        super(plugin, String.format("Heads - Page %d/%d", pageIndex+1, results.pageCount()));
         openView(plugin, results, pageIndex, "");
     }
     public HeadListView(CreativeHeads plugin, Pagination<CustomHead> results, String search) {
         this(plugin, results, 0, search);
     }
     public HeadListView(CreativeHeads plugin, Pagination<CustomHead> results, int pageIndex, String search) {
-        super(plugin, String.format("Heads Search: "+search+" - Page %d of %d", pageIndex+1, results.pageCount()));
+        super(plugin, String.format("Head search: "+search+" - Page %d/%d", pageIndex+1, results.pageCount()));
         openView(plugin, results, pageIndex, search);
     }
 
@@ -76,7 +76,7 @@ public class HeadListView extends InventoryGUI {
                 ItemBuilder.of(Material.LIME_STAINED_GLASS_PANE).withName(ChatColor.GREEN + "\u25C0 Previous page").build(),
                 (player, click) -> {
                     player.playSound(player.getLocation(), Sound.ITEM_BOOK_PAGE_TURN, 1, 1);
-                    new HeadListView(plugin, results, pageIndex - 1).open(player);
+                    new HeadListView(plugin, results, pageIndex-1, search).open(player);
                     return false;
                 }
             );
@@ -93,7 +93,7 @@ public class HeadListView extends InventoryGUI {
                 ItemBuilder.of(Material.LIME_STAINED_GLASS_PANE).withName(ChatColor.GREEN + "Next page \u25B6").build(),
                 (player, click) -> {
                     player.playSound(player.getLocation(), Sound.ITEM_BOOK_PAGE_TURN, 1, 1);
-                    new HeadListView(plugin, results, pageIndex + 1).open(player);
+                    new HeadListView(plugin, results, pageIndex+1, search).open(player);
                     return false;
                 }
             );

--- a/src/main/java/io/github/theluca98/creativeheads/gui/HeadListView.java
+++ b/src/main/java/io/github/theluca98/creativeheads/gui/HeadListView.java
@@ -45,12 +45,8 @@ public class HeadListView extends InventoryGUI {
         this(plugin, results, 0, search);
     }
     public HeadListView(CreativeHeads plugin, Pagination<CustomHead> results, int pageIndex, String search) {
-        if (search == "") {
-            this(plugin, results, pageIndex);
-        } else {
-            super(plugin, String.format("Head search: "+search+" - Page %d/%d", pageIndex+1, results.pageCount()));
-            openView(plugin, results, pageIndex, search);
-        }
+        super(plugin, String.format(((search == "") ? "Heads - Page %d/%d" : "Head search: "+search+" - Page %d/%d"), pageIndex+1, results.pageCount()));
+        openView(plugin, results, pageIndex, search);
     }
 
     public void openView(CreativeHeads plugin, Pagination<CustomHead> results, int pageIndex, String search) {

--- a/src/main/java/io/github/theluca98/creativeheads/repository/LocalRepository.java
+++ b/src/main/java/io/github/theluca98/creativeheads/repository/LocalRepository.java
@@ -77,7 +77,8 @@ public class LocalRepository {
     @SneakyThrows
     private void updateDatabase() {
         if (needsUpdate()) {
-            try (var heads = remote.downloadData()) {
+            try {
+                var heads = remote.downloadData()
                 initializeDatabase();
                 saveData(heads);
             } catch(Exception e) {

--- a/src/main/java/io/github/theluca98/creativeheads/repository/LocalRepository.java
+++ b/src/main/java/io/github/theluca98/creativeheads/repository/LocalRepository.java
@@ -81,8 +81,8 @@ public class LocalRepository {
                 initializeDatabase();
                 saveData(heads);
             } catch(Exception e) {
-                plugin.getLogger().warn("Failed to update from remote database: "+e.getMessage());
-                break;
+                plugin.getLogger().info("Failed to update from remote database: "+e.getMessage());
+                return;
             }
             plugin.getLogger().info("The database is now up to date.");
         } else {

--- a/src/main/java/io/github/theluca98/creativeheads/repository/LocalRepository.java
+++ b/src/main/java/io/github/theluca98/creativeheads/repository/LocalRepository.java
@@ -80,6 +80,9 @@ public class LocalRepository {
             try (var heads = remote.downloadData()) {
                 initializeDatabase();
                 saveData(heads);
+            } catch {
+                plugin.getLogger().warn("Failed to update from remote database.");
+                break;
             }
             plugin.getLogger().info("The database is now up to date.");
         } else {

--- a/src/main/java/io/github/theluca98/creativeheads/repository/LocalRepository.java
+++ b/src/main/java/io/github/theluca98/creativeheads/repository/LocalRepository.java
@@ -80,8 +80,8 @@ public class LocalRepository {
             try (var heads = remote.downloadData()) {
                 initializeDatabase();
                 saveData(heads);
-            } catch {
-                plugin.getLogger().warn("Failed to update from remote database.");
+            } catch(e) {
+                plugin.getLogger().warn("Failed to update from remote database: "+e.getMessage());
                 break;
             }
             plugin.getLogger().info("The database is now up to date.");

--- a/src/main/java/io/github/theluca98/creativeheads/repository/LocalRepository.java
+++ b/src/main/java/io/github/theluca98/creativeheads/repository/LocalRepository.java
@@ -80,7 +80,7 @@ public class LocalRepository {
             try (var heads = remote.downloadData()) {
                 initializeDatabase();
                 saveData(heads);
-            } catch(e) {
+            } catch(Exception e) {
                 plugin.getLogger().warn("Failed to update from remote database: "+e.getMessage());
                 break;
             }

--- a/src/main/java/io/github/theluca98/creativeheads/repository/LocalRepository.java
+++ b/src/main/java/io/github/theluca98/creativeheads/repository/LocalRepository.java
@@ -78,7 +78,7 @@ public class LocalRepository {
     private void updateDatabase() {
         if (needsUpdate()) {
             try {
-                var heads = remote.downloadData()
+                var heads = remote.downloadData();
                 initializeDatabase();
                 saveData(heads);
             } catch(Exception e) {

--- a/src/main/java/io/github/theluca98/creativeheads/repository/RemoteRepository.java
+++ b/src/main/java/io/github/theluca98/creativeheads/repository/RemoteRepository.java
@@ -42,8 +42,7 @@ public class RemoteRepository {
     public RemoteRepository(CreativeHeads plugin) {
         this.plugin = plugin;
         this.client = HttpClient.newHttpClient();
-        this.csvFormat = CSVFormat.Builder
-            .create(CSVFormat.DEFAULT)
+        this.csvFormat = CSVFormat.DEFAULT.builder()
             .setSkipHeaderRecord(true)
             .setHeader()
             .build();

--- a/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
+++ b/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
@@ -30,11 +30,15 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.profile.PlayerProfile;
+import org.bukkit.profile.PlayerTextures;
 import org.bukkit.Bukkit;
 
+
+import java.io.InputStreamReader;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.UUID;
+import java.util.Base64;
 import java.net.URL;
 import java.net.MalformedURLException;
 
@@ -132,7 +136,7 @@ public class ItemBuilder {
 				var playerUUID = getOnlineUUID(playerName);
 				var textureUrl = getSkinURL(playerUUID);
 
-				var profile = Bukkit.createPlayerProfile(getOnlineUUID(playerName), playerName);
+				var profile = Bukkit.createPlayerProfile(new UUID(getOnlineUUID(playerName)), playerName);
 				var textures = profile.getTextures();
 				try {
 						textures.setSkin(new URL(textureUrl));

--- a/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
+++ b/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
@@ -39,6 +39,7 @@ import org.bukkit.Bukkit;
 
 import java.io.InputStreamReader;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.UUID;
@@ -113,7 +114,10 @@ public class ItemBuilder {
 						return UUID.fromString(uuidJson.get("id").getAsString().replaceFirst("(\\w{8})(\\w{4})(\\w{4})(\\w{4})(\\w{12})", "$1-$2-$3-$4-$5"));
 				} catch (FileNotFoundException e) {
                         throw new PlayerNotFound("Online UUID for "+username+" not found.", e);
-				}
+				} catch (IOException | MalformedURLException e) {
+                    e.printStackTrace();
+                    return null;
+                }
 		}
 
 		public String getSkinURL(String uuid) {

--- a/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
+++ b/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
@@ -135,7 +135,6 @@ public class ItemBuilder {
 				}
 		}
 
-		// @SuppressWarnings("deprecation")
 		public ItemBuilder withCustomSkullOwner(String playerName) {
 				checkArgument(meta instanceof SkullMeta, "Not a player head item");
 				var playerUUID = getOnlineUUID(playerName);

--- a/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
+++ b/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
@@ -29,7 +29,7 @@ import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SkullMeta;
-import org.spigotmc.world.item.component.ResolvableProfile;
+import org.bukkit.profile.PlayerProfile;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -78,7 +78,7 @@ public class ItemBuilder {
         var payload = Map.of("textures", Map.of("SKIN", Map.of("url", textureUrl)));
         var json = CreativeHeads.GSON.toJson(payload);
         var base64 = BaseEncoding.base64().encode(json.getBytes(Charsets.UTF_8));
-        var profile = new GameProfile(UUID.randomUUID(), "CreativeHeadsCustomHead");
+        var profile = new PlayerProfile(UUID.randomUUID(), "CreativeHeadsCustomHead");
         profile.getProperties().put("textures", new Property("textures", base64));
         return withCustomSkullProfile(profile);
     }
@@ -86,16 +86,14 @@ public class ItemBuilder {
     @SneakyThrows
     public ItemBuilder withCustomSkullProfile(GameProfile profile) {
         checkArgument(meta instanceof SkullMeta, "Not a player head item");
-        var method = meta.getClass().getDeclaredMethod("setProfile", ResolvableProfile.class);
-        method.setAccessible(true);
-        method.invoke(meta, profile);
+        ((SkullMeta) meta).setOwnerProfile(profile);
         return this;
     }
 
     @SuppressWarnings("deprecation")
     public ItemBuilder withCustomSkullOwner(String playerName) {
         checkArgument(meta instanceof SkullMeta, "Not a player head item");
-        ((SkullMeta) meta).setOwner(playerName);
+        ((SkullMeta) meta).setOwningPlayer(playerName);
         return this;
     }
 

--- a/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
+++ b/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
@@ -79,9 +79,14 @@ public class ItemBuilder {
     public ItemBuilder withCustomSkullTexture(String textureUrl) {
         var profile = Bukkit.createPlayerProfile(UUID.randomUUID(), "CreativeHeadsCustomHead");
         var textures = profile.getTextures();
-        textures.setSkin(new URL(textureUrl));
-        profile.setTextures(textures);
-        return withCustomSkullProfile(profile);
+        try {        
+            textures.setSkin(new URL(textureUrl));
+            profile.setTextures(textures);
+            return withCustomSkullProfile(profile);
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+            return null
+        }
     }
 
     @SneakyThrows

--- a/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
+++ b/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
@@ -79,7 +79,7 @@ public class ItemBuilder {
     public ItemBuilder withCustomSkullTexture(String textureUrl) {
         var profile = Bukkit.createPlayerProfile(UUID.randomUUID(), "CreativeHeadsCustomHead");
         var textures = profile.getTextures();
-        textures.setSkin(new URL(textureUrl));
+        textures.setSkin(new URL(textureUrl));
         profile.setTextures(textures);
         return withCustomSkullProfile(profile);
     }

--- a/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
+++ b/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
@@ -85,7 +85,7 @@ public class ItemBuilder {
             return withCustomSkullProfile(profile);
         } catch (MalformedURLException e) {
             e.printStackTrace();
-            return null
+            return null;
         }
     }
 

--- a/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
+++ b/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
@@ -138,7 +138,6 @@ public class ItemBuilder {
 		// @SuppressWarnings("deprecation")
 		public ItemBuilder withCustomSkullOwner(String playerName) {
 				checkArgument(meta instanceof SkullMeta, "Not a player head item");
-				// ((SkullMeta) meta).setOwningPlayer(Bukkit.getOfflinePlayer(playerName));
 				var playerUUID = getOnlineUUID(playerName);
 				var textureUrl = getSkinURL(playerUUID.toString());
 

--- a/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
+++ b/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
@@ -136,7 +136,7 @@ public class ItemBuilder {
 				checkArgument(meta instanceof SkullMeta, "Not a player head item");
 				// ((SkullMeta) meta).setOwningPlayer(Bukkit.getOfflinePlayer(playerName));
 				var playerUUID = getOnlineUUID(playerName);
-				var textureUrl = getSkinURL(playerUUID);
+				var textureUrl = getSkinURL(playerUUID.asString());
 
 				var profile = Bukkit.createPlayerProfile(playerUUID, playerName);
 				var textures = profile.getTextures();

--- a/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
+++ b/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
@@ -78,7 +78,7 @@ public class ItemBuilder {
     }
 
     public ItemBuilder withCustomSkullTexture(String textureUrl) {
-        var profile = Bukkit.createPlayerProfile(UUID.randomUUID(), "CreativeHeadsCustomHead");
+        var profile = Bukkit.createPlayerProfile(UUID.randomUUID(), "CreativeHeads");
         var textures = profile.getTextures();
         try {        
             textures.setSkin(new URL(textureUrl));

--- a/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
+++ b/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
@@ -146,7 +146,6 @@ public class ItemBuilder {
 						return withCustomSkullProfile(profile);
 				} catch (MalformedURLException e) {
 						e.printStackTrace();
-						return null;
 				}
 				return this;
 		}

--- a/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
+++ b/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
@@ -30,7 +30,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.profile.PlayerProfile;
-import org.bukkit.Server;
+import org.bukkit.Bukkit;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -76,11 +76,8 @@ public class ItemBuilder {
     }
 
     public ItemBuilder withCustomSkullTexture(String textureUrl) {
-        var payload = Map.of("textures", Map.of("SKIN", Map.of("url", textureUrl)));
-        var json = CreativeHeads.GSON.toJson(payload);
-        var base64 = BaseEncoding.base64().encode(json.getBytes(Charsets.UTF_8));
-        var profile = Server.createPlayerProfile(UUID.randomUUID(), "CreativeHeadsCustomHead");
-        profile.getProperties().put("textures", new Property("textures", base64));
+        var profile = Bukkit.createPlayerProfile(UUID.randomUUID(), "CreativeHeadsCustomHead");
+        profile.setTextures(profile.getTextures().setSkin(textureUrl));
         return withCustomSkullProfile(profile);
     }
 
@@ -94,7 +91,7 @@ public class ItemBuilder {
     @SuppressWarnings("deprecation")
     public ItemBuilder withCustomSkullOwner(String playerName) {
         checkArgument(meta instanceof SkullMeta, "Not a player head item");
-        ((SkullMeta) meta).setOwningPlayer(playerName);
+        ((SkullMeta) meta).setOwningPlayer(Bukkit.getOfflinePlayer(playerName));
         return this;
     }
 

--- a/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
+++ b/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
@@ -20,7 +20,6 @@ package io.github.theluca98.creativeheads.util;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.BaseEncoding;
-import net.minecraft.world.item.component.ResolvableProfile;
 import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
 import io.github.theluca98.creativeheads.CreativeHeads;
@@ -30,6 +29,7 @@ import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SkullMeta;
+import org.bukkit.world.item.component.ResolvableProfile;
 
 import java.util.Arrays;
 import java.util.Map;

--- a/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
+++ b/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
@@ -138,7 +138,7 @@ public class ItemBuilder {
 				var playerUUID = getOnlineUUID(playerName);
 				var textureUrl = getSkinURL(playerUUID);
 
-				var profile = Bukkit.createPlayerProfile(new UUID(playerUUID), playerName);
+				var profile = Bukkit.createPlayerProfile(UUID.fromString(playerUUID), playerName);
 				var textures = profile.getTextures();
 				try {
 						textures.setSkin(new URL(textureUrl));

--- a/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
+++ b/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
@@ -78,7 +78,9 @@ public class ItemBuilder {
 
     public ItemBuilder withCustomSkullTexture(String textureUrl) {
         var profile = Bukkit.createPlayerProfile(UUID.randomUUID(), "CreativeHeadsCustomHead");
-        profile.setTextures(profile.getTextures().setSkin(new URL(textureUrl)));
+        var textures = profile.getTextures();
+        textures.setSkin(new URL(textureUrl));
+        profile.setTextures(textures);
         return withCustomSkullProfile(profile);
     }
 

--- a/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
+++ b/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
@@ -77,7 +77,7 @@ public class ItemBuilder {
         var payload = Map.of("textures", Map.of("SKIN", Map.of("url", textureUrl)));
         var json = CreativeHeads.GSON.toJson(payload);
         var base64 = BaseEncoding.base64().encode(json.getBytes(Charsets.UTF_8));
-        var profile = new GameProfile(UUID.randomUUID(), null);
+        var profile = new GameProfile(UUID.randomUUID(), "CreativeHeadsCustomHead");
         profile.getProperties().put("textures", new Property("textures", base64));
         return withCustomSkullProfile(profile);
     }

--- a/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
+++ b/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
@@ -138,7 +138,7 @@ public class ItemBuilder {
 				var playerUUID = getOnlineUUID(playerName);
 				var textureUrl = getSkinURL(playerUUID);
 
-				var profile = Bukkit.createPlayerProfile(new UUID(getOnlineUUID(playerName)), playerName);
+				var profile = Bukkit.createPlayerProfile(new UUID(playerUUID), playerName);
 				var textures = profile.getTextures();
 				try {
 						textures.setSkin(new URL(textureUrl));

--- a/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
+++ b/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
@@ -103,12 +103,12 @@ public class ItemBuilder {
 				}
 		}
 
-		public String getOnlineUUID(String username) {
+		public UUID getOnlineUUID(String username) {
 				try {
 						URL uuidUrl = new URL("https://api.mojang.com/users/profiles/minecraft/" + username);
 						InputStreamReader uuidReader = new InputStreamReader(uuidUrl.openStream());
 						JsonObject uuidJson = JsonParser.parseReader(uuidReader).getAsJsonObject();
-						return uuidJson.get("id").getAsString();
+						return UUID.fromString(uuidJson.get("id").getAsString().replaceFirst("(\\w{8})(\\w{4})(\\w{4})(\\w{4})(\\w{12})", "$1-$2-$3-$4-$5"));
 				} catch (Exception e) {
 						e.printStackTrace();
 						return null;
@@ -138,7 +138,7 @@ public class ItemBuilder {
 				var playerUUID = getOnlineUUID(playerName);
 				var textureUrl = getSkinURL(playerUUID);
 
-				var profile = Bukkit.createPlayerProfile(UUID.fromString(playerUUID), playerName);
+				var profile = Bukkit.createPlayerProfile(playerUUID, playerName);
 				var textures = profile.getTextures();
 				try {
 						textures.setSkin(new URL(textureUrl));

--- a/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
+++ b/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
@@ -114,7 +114,7 @@ public class ItemBuilder {
 						return UUID.fromString(uuidJson.get("id").getAsString().replaceFirst("(\\w{8})(\\w{4})(\\w{4})(\\w{4})(\\w{12})", "$1-$2-$3-$4-$5"));
 				} catch (FileNotFoundException e) {
                         throw new PlayerNotFound("Online UUID for "+username+" not found.", e);
-				} catch (IOException | MalformedURLException e) {
+				} catch (IOException e) {
                     e.printStackTrace();
                     return null;
                 }

--- a/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
+++ b/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
@@ -136,7 +136,7 @@ public class ItemBuilder {
 				checkArgument(meta instanceof SkullMeta, "Not a player head item");
 				// ((SkullMeta) meta).setOwningPlayer(Bukkit.getOfflinePlayer(playerName));
 				var playerUUID = getOnlineUUID(playerName);
-				var textureUrl = getSkinURL(playerUUID.asString());
+				var textureUrl = getSkinURL(playerUUID.toString());
 
 				var profile = Bukkit.createPlayerProfile(playerUUID, playerName);
 				var textures = profile.getTextures();

--- a/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
+++ b/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
@@ -30,7 +30,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.profile.PlayerProfile;
-import org.bukkit.Server
+import org.bukkit.Server;
 
 import java.util.Arrays;
 import java.util.Map;

--- a/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
+++ b/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
@@ -20,6 +20,7 @@ package io.github.theluca98.creativeheads.util;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.BaseEncoding;
+import net.minecraft.world.item.component.ResolvableProfile;
 import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
 import io.github.theluca98.creativeheads.CreativeHeads;

--- a/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
+++ b/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
@@ -29,7 +29,7 @@ import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SkullMeta;
-import org.bukkit.world.item.component.ResolvableProfile;
+import org.spigotmc.world.item.component.ResolvableProfile;
 
 import java.util.Arrays;
 import java.util.Map;

--- a/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
+++ b/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
@@ -85,7 +85,7 @@ public class ItemBuilder {
     @SneakyThrows
     public ItemBuilder withCustomSkullProfile(GameProfile profile) {
         checkArgument(meta instanceof SkullMeta, "Not a player head item");
-        var method = meta.getClass().getDeclaredMethod("setProfile", GameProfile.class);
+        var method = meta.getClass().getDeclaredMethod("setProfile", ResolvableProfile.class);
         method.setAccessible(true);
         method.invoke(meta, profile);
         return this;

--- a/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
+++ b/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
@@ -20,7 +20,7 @@ package io.github.theluca98.creativeheads.util;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.BaseEncoding;
-import com.mojang.authlib.GameProfile;
+// import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
 import io.github.theluca98.creativeheads.CreativeHeads;
 import lombok.SneakyThrows;
@@ -30,6 +30,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.profile.PlayerProfile;
+import org.bukkit.Server
 
 import java.util.Arrays;
 import java.util.Map;
@@ -78,13 +79,13 @@ public class ItemBuilder {
         var payload = Map.of("textures", Map.of("SKIN", Map.of("url", textureUrl)));
         var json = CreativeHeads.GSON.toJson(payload);
         var base64 = BaseEncoding.base64().encode(json.getBytes(Charsets.UTF_8));
-        var profile = new PlayerProfile(UUID.randomUUID(), "CreativeHeadsCustomHead");
+        var profile = Server.createPlayerProfile(UUID.randomUUID(), "CreativeHeadsCustomHead");
         profile.getProperties().put("textures", new Property("textures", base64));
         return withCustomSkullProfile(profile);
     }
 
     @SneakyThrows
-    public ItemBuilder withCustomSkullProfile(GameProfile profile) {
+    public ItemBuilder withCustomSkullProfile(PlayerProfile profile) {
         checkArgument(meta instanceof SkullMeta, "Not a player head item");
         ((SkullMeta) meta).setOwnerProfile(profile);
         return this;

--- a/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
+++ b/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
@@ -25,6 +25,7 @@ import com.google.gson.JsonParser;
 // import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
 import io.github.theluca98.creativeheads.CreativeHeads;
+import io.github.theluca98.creativeheads.util.exception.PlayerNotFound;
 import lombok.SneakyThrows;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemFlag;
@@ -37,6 +38,7 @@ import org.bukkit.Bukkit;
 
 
 import java.io.InputStreamReader;
+import java.io.FileNotFoundException;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.UUID;
@@ -109,9 +111,8 @@ public class ItemBuilder {
 						InputStreamReader uuidReader = new InputStreamReader(uuidUrl.openStream());
 						JsonObject uuidJson = JsonParser.parseReader(uuidReader).getAsJsonObject();
 						return UUID.fromString(uuidJson.get("id").getAsString().replaceFirst("(\\w{8})(\\w{4})(\\w{4})(\\w{4})(\\w{12})", "$1-$2-$3-$4-$5"));
-				} catch (Exception e) {
-						e.printStackTrace();
-						return null;
+				} catch (FileNotFoundException e) {
+                        throw new PlayerNotFound("Online UUID for "+username+" not found.", e)
 				}
 		}
 

--- a/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
+++ b/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
@@ -112,7 +112,7 @@ public class ItemBuilder {
 						JsonObject uuidJson = JsonParser.parseReader(uuidReader).getAsJsonObject();
 						return UUID.fromString(uuidJson.get("id").getAsString().replaceFirst("(\\w{8})(\\w{4})(\\w{4})(\\w{4})(\\w{12})", "$1-$2-$3-$4-$5"));
 				} catch (FileNotFoundException e) {
-                        throw new PlayerNotFound("Online UUID for "+username+" not found.", e)
+                        throw new PlayerNotFound("Online UUID for "+username+" not found.", e);
 				}
 		}
 

--- a/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
+++ b/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
@@ -20,6 +20,8 @@ package io.github.theluca98.creativeheads.util;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.BaseEncoding;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 // import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
 import io.github.theluca98.creativeheads.CreativeHeads;
@@ -106,14 +108,14 @@ public class ItemBuilder {
 						URL uuidUrl = new URL("https://api.mojang.com/users/profiles/minecraft/" + username);
 						InputStreamReader uuidReader = new InputStreamReader(uuidUrl.openStream());
 						JsonObject uuidJson = JsonParser.parseReader(uuidReader).getAsJsonObject();
-						return uuid = uuidJson.get("id").getAsString();
+						return uuidJson.get("id").getAsString();
 				} catch (Exception e) {
 						e.printStackTrace();
 						return null;
 				}
 		}
 
-		public String getSkinUrl(String uuid) {
+		public String getSkinURL(String uuid) {
 				try {
 						URL profileUrl = new URL("https://sessionserver.mojang.com/session/minecraft/profile/" + uuid);
 						InputStreamReader profileReader = new InputStreamReader(profileUrl.openStream());

--- a/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
+++ b/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
@@ -35,6 +35,7 @@ import org.bukkit.Bukkit;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.UUID;
+import java.net.URL;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
@@ -77,7 +78,7 @@ public class ItemBuilder {
 
     public ItemBuilder withCustomSkullTexture(String textureUrl) {
         var profile = Bukkit.createPlayerProfile(UUID.randomUUID(), "CreativeHeadsCustomHead");
-        profile.setTextures(profile.getTextures().setSkin(textureUrl));
+        profile.setTextures(profile.getTextures().setSkin(new URL(textureUrl)));
         return withCustomSkullProfile(profile);
     }
 

--- a/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
+++ b/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
@@ -36,6 +36,7 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.UUID;
 import java.net.URL;
+import java.net.MalformedURLException;
 
 import static com.google.common.base.Preconditions.checkArgument;
 

--- a/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
+++ b/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
@@ -9,11 +9,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * along with this program.	If not, see <https://www.gnu.org/licenses/>.
  */
 
 package io.github.theluca98.creativeheads.util;
@@ -42,112 +42,112 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 public class ItemBuilder {
 
-    private final ItemStack item;
-    private final ItemMeta meta;
+		private final ItemStack item;
+		private final ItemMeta meta;
 
-    private ItemBuilder(ItemStack item) {
-        this.item = item;
-        this.meta = item.getItemMeta();
-    }
+		private ItemBuilder(ItemStack item) {
+				this.item = item;
+				this.meta = item.getItemMeta();
+		}
 
-    public static ItemBuilder of(Material material, int amount) {
-        return new ItemBuilder(new ItemStack(material, amount));
-    }
+		public static ItemBuilder of(Material material, int amount) {
+				return new ItemBuilder(new ItemStack(material, amount));
+		}
 
-    public static ItemBuilder of(Material material) {
-        return new ItemBuilder(new ItemStack(material));
-    }
+		public static ItemBuilder of(Material material) {
+				return new ItemBuilder(new ItemStack(material));
+		}
 
-    public static ItemBuilder from(ItemStack item) {
-        return new ItemBuilder(item.clone());
-    }
+		public static ItemBuilder from(ItemStack item) {
+				return new ItemBuilder(item.clone());
+		}
 
-    public ItemBuilder withName(String name) {
-        meta.setDisplayName(name);
-        return this;
-    }
+		public ItemBuilder withName(String name) {
+				meta.setDisplayName(name);
+				return this;
+		}
 
-    public ItemBuilder withLore(String... lore) {
-        meta.setLore(Arrays.asList(lore));
-        return this;
-    }
+		public ItemBuilder withLore(String... lore) {
+				meta.setLore(Arrays.asList(lore));
+				return this;
+		}
 
-    public ItemBuilder withHiddenAttributes() {
-        meta.addItemFlags(ItemFlag.values());
-        return this;
-    }
-  
-    @SneakyThrows
-    public ItemBuilder withCustomSkullProfile(PlayerProfile profile) {
-        checkArgument(meta instanceof SkullMeta, "Not a player head item");
-        ((SkullMeta) meta).setOwnerProfile(profile);
-        return this;
-    }
+		public ItemBuilder withHiddenAttributes() {
+				meta.addItemFlags(ItemFlag.values());
+				return this;
+		}
 
-    public ItemBuilder withCustomSkullTexture(String textureUrl) {
-        var profile = Bukkit.createPlayerProfile(UUID.randomUUID(), "CreativeHeads");
-        var textures = profile.getTextures();
-        try {        
-            textures.setSkin(new URL(textureUrl));
-            profile.setTextures(textures);
-            return withCustomSkullProfile(profile);
-        } catch (MalformedURLException e) {
-            e.printStackTrace();
-            return null;
-        }
-    }
+		@SneakyThrows
+		public ItemBuilder withCustomSkullProfile(PlayerProfile profile) {
+				checkArgument(meta instanceof SkullMeta, "Not a player head item");
+				((SkullMeta) meta).setOwnerProfile(profile);
+				return this;
+		}
 
-    public String getOnlineUUID(String username) {
-        try {
-            URL uuidUrl = new URL("https://api.mojang.com/users/profiles/minecraft/" + username);
-            InputStreamReader uuidReader = new InputStreamReader(uuidUrl.openStream());
-            JsonObject uuidJson = JsonParser.parseReader(uuidReader).getAsJsonObject();
-            return uuid = uuidJson.get("id").getAsString();
-        } catch (Exception e) {
-            e.printStackTrace();
-            return null;
-        }
-    }
+		public ItemBuilder withCustomSkullTexture(String textureUrl) {
+				var profile = Bukkit.createPlayerProfile(UUID.randomUUID(), "CreativeHeads");
+				var textures = profile.getTextures();
+				try {
+						textures.setSkin(new URL(textureUrl));
+						profile.setTextures(textures);
+						return withCustomSkullProfile(profile);
+				} catch (MalformedURLException e) {
+						e.printStackTrace();
+						return null;
+				}
+		}
 
-    public String getSkinUrl(String uuid) {
-        try {
-            URL profileUrl = new URL("https://sessionserver.mojang.com/session/minecraft/profile/" + uuid);
-            InputStreamReader profileReader = new InputStreamReader(profileUrl.openStream());
-            JsonObject profileJson = JsonParser.parseReader(profileReader).getAsJsonObject();
-            JsonObject properties = profileJson.get("properties").getAsJsonArray().get(0).getAsJsonObject();
-            String texture = properties.get("value").getAsString();
+		public String getOnlineUUID(String username) {
+				try {
+						URL uuidUrl = new URL("https://api.mojang.com/users/profiles/minecraft/" + username);
+						InputStreamReader uuidReader = new InputStreamReader(uuidUrl.openStream());
+						JsonObject uuidJson = JsonParser.parseReader(uuidReader).getAsJsonObject();
+						return uuid = uuidJson.get("id").getAsString();
+				} catch (Exception e) {
+						e.printStackTrace();
+						return null;
+				}
+		}
 
-            JsonObject textureJson = JsonParser.parseString(new String(Base64.getDecoder().decode(texture))).getAsJsonObject();
-            return textureJson.get("textures").getAsJsonObject().get("SKIN").getAsJsonObject().get("url").getAsString();
-        } catch (Exception e) {
-            e.printStackTrace();
-            return null;
-        }
-    }
+		public String getSkinUrl(String uuid) {
+				try {
+						URL profileUrl = new URL("https://sessionserver.mojang.com/session/minecraft/profile/" + uuid);
+						InputStreamReader profileReader = new InputStreamReader(profileUrl.openStream());
+						JsonObject profileJson = JsonParser.parseReader(profileReader).getAsJsonObject();
+						JsonObject properties = profileJson.get("properties").getAsJsonArray().get(0).getAsJsonObject();
+						String texture = properties.get("value").getAsString();
 
-    // @SuppressWarnings("deprecation")
-    public ItemBuilder withCustomSkullOwner(String playerName) {
-        checkArgument(meta instanceof SkullMeta, "Not a player head item");
-        // ((SkullMeta) meta).setOwningPlayer(Bukkit.getOfflinePlayer(playerName));
-        var playerUUID = getOnlineUUID(playerName);
-        var textureUrl = getSkinURL(playerUUID);
+						JsonObject textureJson = JsonParser.parseString(new String(Base64.getDecoder().decode(texture))).getAsJsonObject();
+						return textureJson.get("textures").getAsJsonObject().get("SKIN").getAsJsonObject().get("url").getAsString();
+				} catch (Exception e) {
+						e.printStackTrace();
+						return null;
+				}
+		}
 
-        var profile = Bukkit.createPlayerProfile(getOnlineUUID(playerName), playerName);
-        var textures = profile.getTextures();
-        try {        
-            textures.setSkin(new URL(textureUrl));
-            profile.setTextures(textures);
-            return withCustomSkullProfile(profile);
-        } catch (MalformedURLException e) {
-            e.printStackTrace();
-            return null;
-        }
-        return this;
-    }
+		// @SuppressWarnings("deprecation")
+		public ItemBuilder withCustomSkullOwner(String playerName) {
+				checkArgument(meta instanceof SkullMeta, "Not a player head item");
+				// ((SkullMeta) meta).setOwningPlayer(Bukkit.getOfflinePlayer(playerName));
+				var playerUUID = getOnlineUUID(playerName);
+				var textureUrl = getSkinURL(playerUUID);
 
-    public ItemStack build() {
-        item.setItemMeta(meta);
-        return item;
-    }
+				var profile = Bukkit.createPlayerProfile(getOnlineUUID(playerName), playerName);
+				var textures = profile.getTextures();
+				try {
+						textures.setSkin(new URL(textureUrl));
+						profile.setTextures(textures);
+						return withCustomSkullProfile(profile);
+				} catch (MalformedURLException e) {
+						e.printStackTrace();
+						return null;
+				}
+				return this;
+		}
+
+		public ItemStack build() {
+				item.setItemMeta(meta);
+				return item;
+		}
 
 }

--- a/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
+++ b/src/main/java/io/github/theluca98/creativeheads/util/ItemBuilder.java
@@ -22,7 +22,6 @@ import com.google.common.base.Charsets;
 import com.google.common.io.BaseEncoding;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-// import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
 import io.github.theluca98.creativeheads.CreativeHeads;
 import io.github.theluca98.creativeheads.util.exception.PlayerNotFound;

--- a/src/main/java/io/github/theluca98/creativeheads/util/exception/PlayerNotFound.java
+++ b/src/main/java/io/github/theluca98/creativeheads/util/exception/PlayerNotFound.java
@@ -1,0 +1,16 @@
+package io.github.theluca98.creativeheads.util.exception;
+  
+public class PlayerNotFound extends Exception {
+    public PlayerNotFound() {
+        super();
+    }
+    public PlayerNotFound(String message) {
+        super(message);
+    }
+    public PlayerNotFound(String message, Throwable cause) {
+        super(message, cause);
+    }
+    public PlayerNotFound(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/io/github/theluca98/creativeheads/util/exception/PlayerNotFound.java
+++ b/src/main/java/io/github/theluca98/creativeheads/util/exception/PlayerNotFound.java
@@ -1,6 +1,6 @@
 package io.github.theluca98.creativeheads.util.exception;
   
-public class PlayerNotFound extends Exception {
+public class PlayerNotFound extends RuntimeException {
     public PlayerNotFound() {
         super();
     }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: "CreativeHeads"
 version: "${project.version}"
 main: "io.github.theluca98.creativeheads.CreativeHeads"
-api-version: "1.16"
+api-version: "1.21.1"
 author: "Luca"
 website: "https://github.com/TheLuca98/CreativeHeads"
 


### PR DESCRIPTION
Personally I use 1.21.1, but this should work for other newer versions.

In this PR:
   - UPDATE dependencies (and java 17 and spigot 1.21.1)
       - ADDED dependabot, it is WRONG about the Mojang Brigadier update; comment "@dependabot ignore this dependency" on the '1.0.500' PR  to stop it creating PRs for the nonexistent version. You can check for real updates at [GitHub.com/Mojang/brigadier](https://github.com/Mojang/brigadier)
   - FIX 'search' and 'browse' - replace GameProfile with PlayerProfile (and necessary changes with that) to fix issues with the custom heads
   - FIX - add name to custom heads since null is not allowed anymore
   - FIXED command dispatcher problem with new versions
   - ADDED "Back to categories" button when using 'browse' - doesn't show up when using 'search'
   - ADDED the search query to the GUI title (also required making the overall title shorter - now "1/1" instead of "1 of 1")
   - FIX/ADD calling Mojang API for loading player skins when using 'player' (even when player has never joined the server before)
       - also needed custom Exception for error handling when username doesn't exist

This is my first true experience with Bukkit plugins, so ignore the 5 gazillion extra commits. :) (I also had to do everything directly in GitHub without IntelliJ)

The new features were requested by someone in my server and since it wasn't too complicated, I went ahead and added them at the same time.


This is a great free alternative to Head Database so I wanted to keep it alive!